### PR TITLE
Usability improvements.

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+trailingComma: "es5"
+tabWidth: 2
+semi: true
+singleQuote: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawable",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A way to make styling canvas elements like text and images nicer",
   "main": "dist/index.js",
   "author": "Jacob Lowe",

--- a/src/drawable.js
+++ b/src/drawable.js
@@ -71,8 +71,8 @@ export default class Drawable {
       }, Promise.resolve());
   }
 
-  toBuffer() {
-    return this._canvas.toBuffer();
+  toBuffer(...args) {
+    return this._canvas.toBuffer(...args);
   }
 
   toDataURL(...args) {

--- a/src/image.js
+++ b/src/image.js
@@ -8,7 +8,7 @@ export default class DrawableImage {
   constructor(img, styles = {}) {
     // be able to set image buffer
     if (isBuffer(img)) {
-      this._image = new Image
+      this._image = new Image();
       this._image.src = img;
       this._dimensions = sizeOf(img);
     } else {
@@ -46,7 +46,7 @@ export default class DrawableImage {
       return {
         height: adjustedHeight,
         width: adjustedWidth,
-        left: (adjustedWidth - canvasWidth) / 2 * -1,
+        left: ((adjustedWidth - canvasWidth) / 2) * -1,
         top: 0,
       };
     } else {
@@ -55,7 +55,7 @@ export default class DrawableImage {
       return {
         height: adjustedHeight,
         width: adjustedWidth,
-        top: (adjustedHeight - canvasHeight) / 2 * -1,
+        top: ((adjustedHeight - canvasHeight) / 2) * -1,
         left: 0,
       };
     }
@@ -63,6 +63,10 @@ export default class DrawableImage {
 
   getStyleProp(prop = '') {
     return this._styles[prop] || 0;
+  }
+
+  setStyleProp(prop = '', value) {
+    this._styles[prop] = value;
   }
 
   drawImage(context, canvasStyles) {

--- a/src/text.js
+++ b/src/text.js
@@ -34,6 +34,26 @@ export default class Text {
     return this._styles[prop] || 0;
   }
 
+  setStyleProp(prop = '', value) {
+    this._styles[prop] = value;
+  }
+
+  setupContextFonts(context) {
+    const fontSize = this.getStyleProp('fontSize');
+    const fontFamily = this.getStyleProp('fontFamily') || 'sans-serif';
+    const color = this.getStyleProp('color') || '#222';
+    context.textBaseline = 'top';
+    context.font = `normal normal ${fontSize}px ${fontFamily}`;
+    context.fillStyle = color;
+  }
+
+  getTextHeight({ canvasStyles, _context: context }) {
+    const { width } = canvasStyles;
+    this.setupContextFonts(context);
+    const lines = this.getLines(context, this.getMaxWidth(width));
+    return lines.length * this.getStyleProp('lineHeight');
+  }
+
   getSideMargin(text, canvasWidth, context) {
     const align = this._styles.textAlign || 'left';
     const left = this.getStyleProp('left');
@@ -56,10 +76,7 @@ export default class Text {
   draw(context, canvasStyles = {}) {
     const { width: canvasWidth } = canvasStyles;
 
-    context.textBaseline = 'top';
-    context.font = `normal normal ${this.getStyleProp('fontSize')}px ${this
-      ._styles.fontFamily || 'sans-serif'}`;
-    context.fillStyle = this._styles.color || '#222';
+    this.setupContextFonts(context);
 
     const lines = this.getLines(context, this.getMaxWidth(canvasWidth));
 

--- a/tests/text.test.js
+++ b/tests/text.test.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+
+const DrawableText = require('../dist/text').default;
+
+test('the DrawableText exports', t => {
+  t.is(
+    typeof DrawableImage,
+    'function',
+    'Drawable export is a constructor function'
+  );
+});
+
+test('the DrawableText constructor', t => {
+  const styles = { foo: 'bar' };
+  const text = new DrawableText('foo', styles);
+  t.deepEqual(text._styles, styles, 'it should cache the styles');
+  t.is(text._text, 'foo', 'it should cache the first param');
+});
+
+test('"getStyleProp" method should return 0 if no style is present', t => {
+  const text = new DrawableText('');
+
+  t.is(text.getStyleProp('foo'), 0, 'it returned a zero');
+});
+
+test('"getStyleProp" method should return the value of the passed in styles if it is present', t => {
+  const text = new DrawableText('', { foo: 'bar' });
+  t.is(text.getStyleProp('foo'), 'bar', 'it returned the passed in value');
+});

--- a/tests/text.test.js
+++ b/tests/text.test.js
@@ -4,7 +4,7 @@ const DrawableText = require('../dist/text').default;
 
 test('the DrawableText exports', t => {
   t.is(
-    typeof DrawableImage,
+    typeof DrawableText,
     'function',
     'Drawable export is a constructor function'
   );


### PR DESCRIPTION
## Adds

* setStyleProp to Drawable[text|image]
* getTextHeight to Drawable.text
* prettier config
* add test file for text
* pass all args to node-canvas toBuffer
  * this helps if you want to export jpg rather than png.